### PR TITLE
Fix: termCSS concatenation

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ exports.decorateConfig = (config) => {
     cursorColor: CURSOR_COLOR,
     colors,
     termCSS: `
+      ${config.termCSS || ''}
       .cursor-node[focus=true]:not([moving]) {
         animation: blink 1s ease infinite;
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
 
   "name": "hyper-ayu-mirage",


### PR DESCRIPTION
The theme wasn't concatenating the termCSS property in the configuration thus preventing the rendering of the css ligatures