### PR TITLE
Added a fix for when windowControlsCSS is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const colors = {
 };
 
 exports.decorateConfig = (config) => {
-  let windowControlsCSS;
+  let windowControlsCSS = '';
   if (config.showWindowControls) {
     windowControlsCSS = '.list_2902 { margin-left: 0 !important; }';
   }
@@ -167,7 +167,7 @@ exports.decorateConfig = (config) => {
         color: ${TAB_TEXT_COLOR};
         font-weight: 600;
       }
-      ${windowControlsCSS || ''}
+      ${windowControlsCSS}
     `
   });
 };

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ exports.decorateConfig = (config) => {
         color: ${TAB_TEXT_COLOR};
         font-weight: 600;
       }
-      ${windowControlsCSS}
+      ${windowControlsCSS || ''}
     `
   });
 };


### PR DESCRIPTION
Previously `undefined` was entered into the CSS block if `windowControlsCSS` wasn't defined.